### PR TITLE
Fix host permissions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,8 +9,7 @@
     ]
   },
   "permissions": [
-    "https://twitter.com/i/videos/*",
-    "<all_urls>",
+    "https://*.twitter.com/*",
     "webRequest",
     "webRequestBlocking"
   ],


### PR DESCRIPTION
Firefox requires your host permission to include both the source and target of a request. I think this should work. Tested on tweetdeck.twitter.com